### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/batch/src/main/java/com/manning/siia/batch/Account.java
+++ b/siia-examples/batch/src/main/java/com/manning/siia/batch/Account.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/batch/src/main/java/com/manning/siia/batch/ExecutionsToMailTransformer.java
+++ b/siia-examples/batch/src/main/java/com/manning/siia/batch/ExecutionsToMailTransformer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/batch/src/main/java/com/manning/siia/batch/FileMessageToJobRequest.java
+++ b/siia-examples/batch/src/main/java/com/manning/siia/batch/FileMessageToJobRequest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/batch/src/main/java/com/manning/siia/batch/JobExecutionsRouter.java
+++ b/siia-examples/batch/src/main/java/com/manning/siia/batch/JobExecutionsRouter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/batch/src/main/java/com/manning/siia/batch/JobRestart.java
+++ b/siia-examples/batch/src/main/java/com/manning/siia/batch/JobRestart.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/batch/src/main/java/com/manning/siia/batch/Notification.java
+++ b/siia-examples/batch/src/main/java/com/manning/siia/batch/Notification.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/batch/src/main/java/com/manning/siia/batch/Payment.java
+++ b/siia-examples/batch/src/main/java/com/manning/siia/batch/Payment.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/batch/src/main/java/com/manning/siia/batch/PaymentChunkListener.java
+++ b/siia-examples/batch/src/main/java/com/manning/siia/batch/PaymentChunkListener.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/batch/src/main/java/com/manning/siia/batch/PaymentFieldSetMapper.java
+++ b/siia-examples/batch/src/main/java/com/manning/siia/batch/PaymentFieldSetMapper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/batch/src/main/java/com/manning/siia/batch/PaymentWriter.java
+++ b/siia-examples/batch/src/main/java/com/manning/siia/batch/PaymentWriter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/batch/src/main/java/com/manning/siia/batch/StubJavaMailSender.java
+++ b/siia-examples/batch/src/main/java/com/manning/siia/batch/StubJavaMailSender.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/batch/src/test/java/com/manning/siia/batch/BatchTest.java
+++ b/siia-examples/batch/src/test/java/com/manning/siia/batch/BatchTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/batch/src/test/resources/batch-config.xml
+++ b/siia-examples/batch/src/test/resources/batch-config.xml
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/batch/src/test/resources/dbinit.sql
+++ b/siia-examples/batch/src/test/resources/dbinit.sql
@@ -5,7 +5,7 @@
 -- you may not use this file except in compliance with the License.
 -- You may obtain a copy of the License at
 --
---      http://www.apache.org/licenses/LICENSE-2.0
+--      https://www.apache.org/licenses/LICENSE-2.0
 --
 -- Unless required by applicable law or agreed to in writing, software
 -- distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/batch/src/test/resources/si-config.xml
+++ b/siia-examples/batch/src/test/resources/si-config.xml
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/business/src/main/java/siia/business/Airport.java
+++ b/siia-examples/business/src/main/java/siia/business/Airport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/business/src/main/java/siia/business/Crew.java
+++ b/siia-examples/business/src/main/java/siia/business/Crew.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/business/src/main/java/siia/business/EmailHeaderEnricher.java
+++ b/siia-examples/business/src/main/java/siia/business/EmailHeaderEnricher.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/business/src/main/java/siia/business/Equipment.java
+++ b/siia-examples/business/src/main/java/siia/business/Equipment.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/business/src/main/java/siia/business/Flight.java
+++ b/siia-examples/business/src/main/java/siia/business/Flight.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/business/src/main/java/siia/business/FlightDelayEmailGenerator.java
+++ b/siia-examples/business/src/main/java/siia/business/FlightDelayEmailGenerator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/business/src/main/java/siia/business/FlightDelayEvent.java
+++ b/siia-examples/business/src/main/java/siia/business/FlightDelayEvent.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/business/src/main/java/siia/business/FlightEventTransformer.java
+++ b/siia-examples/business/src/main/java/siia/business/FlightEventTransformer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/business/src/main/java/siia/business/FlightScheduler.java
+++ b/siia-examples/business/src/main/java/siia/business/FlightScheduler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/business/src/main/java/siia/business/FlightStatus.java
+++ b/siia-examples/business/src/main/java/siia/business/FlightStatus.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/business/src/main/java/siia/business/FlightStatusEvent.java
+++ b/siia-examples/business/src/main/java/siia/business/FlightStatusEvent.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/business/src/main/java/siia/business/FlightStatusNotificationPublisher.java
+++ b/siia-examples/business/src/main/java/siia/business/FlightStatusNotificationPublisher.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/business/src/main/java/siia/business/FlightStatusService.java
+++ b/siia-examples/business/src/main/java/siia/business/FlightStatusService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/business/src/main/java/siia/business/FrequentFlyerService.java
+++ b/siia-examples/business/src/main/java/siia/business/FrequentFlyerService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/business/src/main/java/siia/business/NotificationDemo.java
+++ b/siia-examples/business/src/main/java/siia/business/NotificationDemo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/business/src/main/java/siia/business/Passenger.java
+++ b/siia-examples/business/src/main/java/siia/business/Passenger.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/business/src/main/java/siia/business/PassengerProfileEnricher.java
+++ b/siia-examples/business/src/main/java/siia/business/PassengerProfileEnricher.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/business/src/main/java/siia/business/Profile.java
+++ b/siia-examples/business/src/main/java/siia/business/Profile.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/business/src/main/java/siia/business/Seat.java
+++ b/siia-examples/business/src/main/java/siia/business/Seat.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/business/src/main/java/siia/business/SimpleFlightStatusService.java
+++ b/siia-examples/business/src/main/java/siia/business/SimpleFlightStatusService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/business/src/main/resources/chain.xml
+++ b/siia-examples/business/src/main/resources/chain.xml
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/business/src/main/resources/flightStatus.xml
+++ b/siia-examples/business/src/main/resources/flightStatus.xml
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/business/src/main/resources/notificationPublisher.xml
+++ b/siia-examples/business/src/main/resources/notificationPublisher.xml
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/business/src/test/java/siia/business/ChainTests.java
+++ b/siia-examples/business/src/test/java/siia/business/ChainTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/business/src/test/java/siia/business/EmailHeaderEnricherTests.java
+++ b/siia-examples/business/src/test/java/siia/business/EmailHeaderEnricherTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/business/src/test/java/siia/business/ExpressionBasedHeaderEnricherTests.java
+++ b/siia-examples/business/src/test/java/siia/business/ExpressionBasedHeaderEnricherTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/business/src/test/java/siia/business/FlightDelayTransformerIntegrationTests.java
+++ b/siia-examples/business/src/test/java/siia/business/FlightDelayTransformerIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/business/src/test/java/siia/business/FlightStatusPublisherTests.java
+++ b/siia-examples/business/src/test/java/siia/business/FlightStatusPublisherTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/business/src/test/java/siia/business/PassengerProfileEnricherTest.java
+++ b/siia-examples/business/src/test/java/siia/business/PassengerProfileEnricherTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/business/src/test/java/siia/business/StubFlightScheduler.java
+++ b/siia-examples/business/src/test/java/siia/business/StubFlightScheduler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/business/src/test/java/siia/business/StubFrequentFlyerService.java
+++ b/siia-examples/business/src/test/java/siia/business/StubFrequentFlyerService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/business/src/test/java/siia/business/StubMailSender.java
+++ b/siia-examples/business/src/test/java/siia/business/StubMailSender.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/business/src/test/resources/siia/business/EmailHeaderEnricherTests-context.xml
+++ b/siia-examples/business/src/test/resources/siia/business/EmailHeaderEnricherTests-context.xml
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/business/src/test/resources/siia/business/ExpressionBasedHeaderEnricherTests-context.xml
+++ b/siia-examples/business/src/test/resources/siia/business/ExpressionBasedHeaderEnricherTests-context.xml
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/business/src/test/resources/siia/business/FlightDelayTransformerIntegrationTests-context.xml
+++ b/siia-examples/business/src/test/resources/siia/business/FlightDelayTransformerIntegrationTests-context.xml
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/business/src/test/resources/siia/business/FlightStatusPublisherTests-context.xml
+++ b/siia-examples/business/src/test/resources/siia/business/FlightStatusPublisherTests-context.xml
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/concurrency/src/main/java/com/manning/siia/pipeline/AssembledCar.java
+++ b/siia-examples/concurrency/src/main/java/com/manning/siia/pipeline/AssembledCar.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/concurrency/src/main/java/com/manning/siia/pipeline/AssemblyLine.java
+++ b/siia-examples/concurrency/src/main/java/com/manning/siia/pipeline/AssemblyLine.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/concurrency/src/main/java/com/manning/siia/pipeline/Counter.java
+++ b/siia-examples/concurrency/src/main/java/com/manning/siia/pipeline/Counter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/concurrency/src/main/java/com/manning/siia/pipeline/FinishedCar.java
+++ b/siia-examples/concurrency/src/main/java/com/manning/siia/pipeline/FinishedCar.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/concurrency/src/main/java/com/manning/siia/pipeline/PaintShop.java
+++ b/siia-examples/concurrency/src/main/java/com/manning/siia/pipeline/PaintShop.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/concurrency/src/main/java/com/manning/siia/pipeline/PieceKit.java
+++ b/siia-examples/concurrency/src/main/java/com/manning/siia/pipeline/PieceKit.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/concurrency/src/main/java/com/manning/siia/pipeline/SupplyInput.java
+++ b/siia-examples/concurrency/src/main/java/com/manning/siia/pipeline/SupplyInput.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/concurrency/src/main/resources/paint-shop-concurrent.xml
+++ b/siia-examples/concurrency/src/main/resources/paint-shop-concurrent.xml
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/concurrency/src/main/resources/paint-shop.xml
+++ b/siia-examples/concurrency/src/main/resources/paint-shop.xml
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/concurrency/src/test/java/com/manning/siia/pipeline/PaintShopConcurrentTests.java
+++ b/siia-examples/concurrency/src/test/java/com/manning/siia/pipeline/PaintShopConcurrentTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/concurrency/src/test/java/com/manning/siia/pipeline/PaintShopDirectTests.java
+++ b/siia-examples/concurrency/src/test/java/com/manning/siia/pipeline/PaintShopDirectTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/concurrency/src/test/java/siia/concurrency/AdvancedPollerTests.java
+++ b/siia-examples/concurrency/src/test/java/siia/concurrency/AdvancedPollerTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/concurrency/src/test/java/siia/concurrency/CronPollerTests.java
+++ b/siia-examples/concurrency/src/test/java/siia/concurrency/CronPollerTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/concurrency/src/test/java/siia/concurrency/PollerDefaultAndCustomTest.java
+++ b/siia-examples/concurrency/src/test/java/siia/concurrency/PollerDefaultAndCustomTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/concurrency/src/test/java/siia/concurrency/StubComparator.java
+++ b/siia-examples/concurrency/src/test/java/siia/concurrency/StubComparator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/concurrency/src/test/java/siia/concurrency/StubFilter.java
+++ b/siia-examples/concurrency/src/test/java/siia/concurrency/StubFilter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/concurrency/src/test/java/siia/concurrency/StubService.java
+++ b/siia-examples/concurrency/src/test/java/siia/concurrency/StubService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/concurrency/src/test/resources/siia/concurrency/AdvancedPollerTests-context.xml
+++ b/siia-examples/concurrency/src/test/resources/siia/concurrency/AdvancedPollerTests-context.xml
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/concurrency/src/test/resources/siia/concurrency/CronPollerTests-context.xml
+++ b/siia-examples/concurrency/src/test/resources/siia/concurrency/CronPollerTests-context.xml
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/concurrency/src/test/resources/siia/concurrency/PollerDefaultAndCustomTest-context.xml
+++ b/siia-examples/concurrency/src/test/resources/siia/concurrency/PollerDefaultAndCustomTest-context.xml
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/Command.java
+++ b/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/Command.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/FinancialAmount.java
+++ b/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/FinancialAmount.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/Location.java
+++ b/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/Location.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/binding/JodaDateTimeAdapter.java
+++ b/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/binding/JodaDateTimeAdapter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/cancellation/CancellationConfirmation.java
+++ b/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/cancellation/CancellationConfirmation.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/cancellation/CancellationRequest.java
+++ b/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/cancellation/CancellationRequest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/cancellation/CancellationsService.java
+++ b/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/cancellation/CancellationsService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/cancellation/StubCancellationsService.java
+++ b/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/cancellation/StubCancellationsService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/car/CarCriteria.java
+++ b/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/car/CarCriteria.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/car/CarRental.java
+++ b/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/car/CarRental.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/car/CarRentalBooking.java
+++ b/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/car/CarRentalBooking.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/car/CarRentalQuote.java
+++ b/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/car/CarRentalQuote.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/car/CarType.java
+++ b/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/car/CarType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/flight/Flight.java
+++ b/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/flight/Flight.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/flight/FlightBooking.java
+++ b/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/flight/FlightBooking.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/flight/FlightCriteria.java
+++ b/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/flight/FlightCriteria.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/flight/FlightQuote.java
+++ b/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/flight/FlightQuote.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/flight/FlightSchedule.java
+++ b/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/flight/FlightSchedule.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/flight/FlightSeatClass.java
+++ b/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/flight/FlightSeatClass.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/hotel/Hotel.java
+++ b/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/hotel/Hotel.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/hotel/HotelBooking.java
+++ b/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/hotel/HotelBooking.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/hotel/HotelCriteria.java
+++ b/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/hotel/HotelCriteria.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/hotel/HotelQuote.java
+++ b/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/hotel/HotelQuote.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/hotel/RoomType.java
+++ b/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/hotel/RoomType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/notifications/FlightNotification.java
+++ b/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/notifications/FlightNotification.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/notifications/Notifiable.java
+++ b/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/notifications/Notifiable.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/notifications/Priority.java
+++ b/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/notifications/Priority.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/notifications/SmsNotifiable.java
+++ b/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/notifications/SmsNotifiable.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/notifications/TripNotification.java
+++ b/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/notifications/TripNotification.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/payment/CreditCardPayment.java
+++ b/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/payment/CreditCardPayment.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/payment/CreditCardType.java
+++ b/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/payment/CreditCardType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/payment/Invoice.java
+++ b/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/payment/Invoice.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/payment/PaymentManager.java
+++ b/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/payment/PaymentManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/payment/PaymentSettlement.java
+++ b/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/payment/PaymentSettlement.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/payment/PaypalPayment.java
+++ b/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/payment/PaypalPayment.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/trip/BookedLeg.java
+++ b/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/trip/BookedLeg.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/trip/BookedTrip.java
+++ b/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/trip/BookedTrip.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/trip/CreateTripCommand.java
+++ b/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/trip/CreateTripCommand.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/trip/Leg.java
+++ b/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/trip/Leg.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/trip/LegQuoteCommand.java
+++ b/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/trip/LegQuoteCommand.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/trip/Trip.java
+++ b/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/trip/Trip.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/trip/TripQuoteRequest.java
+++ b/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/trip/TripQuoteRequest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/trip/TripRepository.java
+++ b/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/trip/TripRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/user/User.java
+++ b/siia-examples/flight-booking/domain/src/main/java/siia/booking/domain/user/User.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/domain/src/test/java/siia/booking/domain/trip/LegMarshallingTest.java
+++ b/siia-examples/flight-booking/domain/src/test/java/siia/booking/domain/trip/LegMarshallingTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/domain/src/test/java/siia/booking/domain/trip/LegQuoteMarshallingTest.java
+++ b/siia-examples/flight-booking/domain/src/test/java/siia/booking/domain/trip/LegQuoteMarshallingTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/integration/src/main/java/siia/booking/integration/cancellation/CancellationRequestFilter.java
+++ b/siia-examples/flight-booking/integration/src/main/java/siia/booking/integration/cancellation/CancellationRequestFilter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/integration/src/main/java/siia/booking/integration/cancellation/CancellationsGateway.java
+++ b/siia-examples/flight-booking/integration/src/main/java/siia/booking/integration/cancellation/CancellationsGateway.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/integration/src/main/java/siia/booking/integration/notifications/FlightToTripNotificationsSplitter.java
+++ b/siia-examples/flight-booking/integration/src/main/java/siia/booking/integration/notifications/FlightToTripNotificationsSplitter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/integration/src/main/java/siia/booking/integration/notifications/NotificationsRouter.java
+++ b/siia-examples/flight-booking/integration/src/main/java/siia/booking/integration/notifications/NotificationsRouter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/integration/src/main/java/siia/booking/integration/notifications/RelatedTripsHeaderEnricher.java
+++ b/siia-examples/flight-booking/integration/src/main/java/siia/booking/integration/notifications/RelatedTripsHeaderEnricher.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/integration/src/main/java/siia/booking/integration/purchases/LegQuoteAggregator.java
+++ b/siia-examples/flight-booking/integration/src/main/java/siia/booking/integration/purchases/LegQuoteAggregator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/integration/src/main/java/siia/booking/integration/routing/PaymentSettlementRouter.java
+++ b/siia-examples/flight-booking/integration/src/main/java/siia/booking/integration/routing/PaymentSettlementRouter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/integration/src/main/resources/bookings.xml
+++ b/siia-examples/flight-booking/integration/src/main/resources/bookings.xml
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/integration/src/main/resources/cancellations.xml
+++ b/siia-examples/flight-booking/integration/src/main/resources/cancellations.xml
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/integration/src/main/resources/cancellationsWithException.xml
+++ b/siia-examples/flight-booking/integration/src/main/resources/cancellationsWithException.xml
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/integration/src/main/resources/cancellationsWithNotification.xml
+++ b/siia-examples/flight-booking/integration/src/main/resources/cancellationsWithNotification.xml
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/integration/src/main/resources/flight-notifications-spel.xml
+++ b/siia-examples/flight-booking/integration/src/main/resources/flight-notifications-spel.xml
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/integration/src/main/resources/flight-notifications.xml
+++ b/siia-examples/flight-booking/integration/src/main/resources/flight-notifications.xml
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/integration/src/main/resources/leg-quote.xml
+++ b/siia-examples/flight-booking/integration/src/main/resources/leg-quote.xml
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/integration/src/main/resources/payment-routing.xml
+++ b/siia-examples/flight-booking/integration/src/main/resources/payment-routing.xml
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/integration/src/main/resources/routing-service-activator.xml
+++ b/siia-examples/flight-booking/integration/src/main/resources/routing-service-activator.xml
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/integration/src/main/resources/trip-commands.xml
+++ b/siia-examples/flight-booking/integration/src/main/resources/trip-commands.xml
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/integration/src/main/resources/weather-endpoint.xml
+++ b/siia-examples/flight-booking/integration/src/main/resources/weather-endpoint.xml
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/integration/src/main/resources/xsd/flightQuote.xsd
+++ b/siia-examples/flight-booking/integration/src/main/resources/xsd/flightQuote.xsd
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/integration/src/main/resources/xsl/enrichCriteriaWithLeg.xsl
+++ b/siia-examples/flight-booking/integration/src/main/resources/xsl/enrichCriteriaWithLeg.xsl
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/integration/src/test/java/siia/booking/integration/BookingHeaderTests.java
+++ b/siia-examples/flight-booking/integration/src/test/java/siia/booking/integration/BookingHeaderTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/integration/src/test/java/siia/booking/integration/CancellationsTest.java
+++ b/siia-examples/flight-booking/integration/src/test/java/siia/booking/integration/CancellationsTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/integration/src/test/java/siia/booking/integration/CancellationsWithExceptionTest.java
+++ b/siia-examples/flight-booking/integration/src/test/java/siia/booking/integration/CancellationsWithExceptionTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/integration/src/test/java/siia/booking/integration/CancellationsWithNotificationTest.java
+++ b/siia-examples/flight-booking/integration/src/test/java/siia/booking/integration/CancellationsWithNotificationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/integration/src/test/java/siia/booking/integration/FlightNotificationsSpelTest.java
+++ b/siia-examples/flight-booking/integration/src/test/java/siia/booking/integration/FlightNotificationsSpelTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/integration/src/test/java/siia/booking/integration/FlightNotificationsTest.java
+++ b/siia-examples/flight-booking/integration/src/test/java/siia/booking/integration/FlightNotificationsTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/integration/src/test/java/siia/booking/integration/LegQuoteIntegrationTest.java
+++ b/siia-examples/flight-booking/integration/src/test/java/siia/booking/integration/LegQuoteIntegrationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/integration/src/test/java/siia/booking/integration/PaymentRoutingTest.java
+++ b/siia-examples/flight-booking/integration/src/test/java/siia/booking/integration/PaymentRoutingTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/integration/src/test/java/siia/booking/integration/StubMailSender.java
+++ b/siia-examples/flight-booking/integration/src/test/java/siia/booking/integration/StubMailSender.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/integration/src/test/java/siia/booking/integration/TripCommandsTest.java
+++ b/siia-examples/flight-booking/integration/src/test/java/siia/booking/integration/TripCommandsTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/integration/src/test/java/siia/booking/integration/WeatherTest.java
+++ b/siia-examples/flight-booking/integration/src/test/java/siia/booking/integration/WeatherTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/integration/src/test/java/siia/booking/integration/notifications/FlightToTripNotificationsSplitterTest.java
+++ b/siia-examples/flight-booking/integration/src/test/java/siia/booking/integration/notifications/FlightToTripNotificationsSplitterTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/integration/src/test/resources/TEST-flight-notifications-spel.xml
+++ b/siia-examples/flight-booking/integration/src/test/resources/TEST-flight-notifications-spel.xml
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/integration/src/test/resources/TEST-flight-notifications.xml
+++ b/siia-examples/flight-booking/integration/src/test/resources/TEST-flight-notifications.xml
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/integration/src/test/resources/TEST-trip-commands.xml
+++ b/siia-examples/flight-booking/integration/src/test/resources/TEST-trip-commands.xml
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/flight-booking/integration/src/test/resources/log4j.properties
+++ b/siia-examples/flight-booking/integration/src/test/resources/log4j.properties
@@ -5,7 +5,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/fundamentals/src/main/java/siia/fundamentals/Booking.java
+++ b/siia-examples/fundamentals/src/main/java/siia/fundamentals/Booking.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/fundamentals/src/main/java/siia/fundamentals/BookingDao.java
+++ b/siia-examples/fundamentals/src/main/java/siia/fundamentals/BookingDao.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/fundamentals/src/main/java/siia/fundamentals/BookingReportingService.java
+++ b/siia-examples/fundamentals/src/main/java/siia/fundamentals/BookingReportingService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/fundamentals/src/main/java/siia/fundamentals/BookingService.java
+++ b/siia-examples/fundamentals/src/main/java/siia/fundamentals/BookingService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/fundamentals/src/main/java/siia/fundamentals/BookingServiceWithInjection.java
+++ b/siia-examples/fundamentals/src/main/java/siia/fundamentals/BookingServiceWithInjection.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/fundamentals/src/main/java/siia/fundamentals/BookingServiceWithStrongCoupling.java
+++ b/siia-examples/fundamentals/src/main/java/siia/fundamentals/BookingServiceWithStrongCoupling.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/fundamentals/src/main/java/siia/fundamentals/MealPreference.java
+++ b/siia-examples/fundamentals/src/main/java/siia/fundamentals/MealPreference.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/fundamentals/src/main/java/siia/fundamentals/MealPreferenceRequestTransformer.java
+++ b/siia-examples/fundamentals/src/main/java/siia/fundamentals/MealPreferenceRequestTransformer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/fundamentals/src/main/java/siia/fundamentals/SimpleBookingDao.java
+++ b/siia-examples/fundamentals/src/main/java/siia/fundamentals/SimpleBookingDao.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/fundamentals/src/main/resources/siia/fundamentals/context.xml
+++ b/siia-examples/fundamentals/src/main/resources/siia/fundamentals/context.xml
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/fundamentals/src/test/java/siia/fundamentals/RunBookingServiceTest.java
+++ b/siia-examples/fundamentals/src/test/java/siia/fundamentals/RunBookingServiceTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/hello-world/src/main/java/siia/helloworld/channel/HelloService.java
+++ b/siia-examples/hello-world/src/main/java/siia/helloworld/channel/HelloService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/hello-world/src/main/java/siia/helloworld/channel/HelloWorldExample.java
+++ b/siia-examples/hello-world/src/main/java/siia/helloworld/channel/HelloWorldExample.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/hello-world/src/main/java/siia/helloworld/channel/MyHelloService.java
+++ b/siia-examples/hello-world/src/main/java/siia/helloworld/channel/MyHelloService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/hello-world/src/main/java/siia/helloworld/gateway/HelloService.java
+++ b/siia-examples/hello-world/src/main/java/siia/helloworld/gateway/HelloService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/hello-world/src/main/java/siia/helloworld/gateway/HelloWorldExample.java
+++ b/siia-examples/hello-world/src/main/java/siia/helloworld/gateway/HelloWorldExample.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/hello-world/src/main/java/siia/helloworld/gateway/MyHelloService.java
+++ b/siia-examples/hello-world/src/main/java/siia/helloworld/gateway/MyHelloService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/hello-world/src/main/resources/siia/helloworld/channel/context.xml
+++ b/siia-examples/hello-world/src/main/resources/siia/helloworld/channel/context.xml
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/hello-world/src/main/resources/siia/helloworld/gateway/context.xml
+++ b/siia-examples/hello-world/src/main/resources/siia/helloworld/gateway/context.xml
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/home-cooking/src/main/java/com/manning/siia/kitchen/Cook.java
+++ b/siia-examples/home-cooking/src/main/java/com/manning/siia/kitchen/Cook.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/home-cooking/src/main/java/com/manning/siia/kitchen/Cupboard.java
+++ b/siia-examples/home-cooking/src/main/java/com/manning/siia/kitchen/Cupboard.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/home-cooking/src/main/java/com/manning/siia/kitchen/ShoppingListWriter.java
+++ b/siia-examples/home-cooking/src/main/java/com/manning/siia/kitchen/ShoppingListWriter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/home-cooking/src/main/java/com/manning/siia/kitchen/domain/Amount.java
+++ b/siia-examples/home-cooking/src/main/java/com/manning/siia/kitchen/domain/Amount.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/home-cooking/src/main/java/com/manning/siia/kitchen/domain/AmountConverter.java
+++ b/siia-examples/home-cooking/src/main/java/com/manning/siia/kitchen/domain/AmountConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/home-cooking/src/main/java/com/manning/siia/kitchen/domain/Grocery.java
+++ b/siia-examples/home-cooking/src/main/java/com/manning/siia/kitchen/domain/Grocery.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/home-cooking/src/main/java/com/manning/siia/kitchen/domain/GroceryBag.java
+++ b/siia-examples/home-cooking/src/main/java/com/manning/siia/kitchen/domain/GroceryBag.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/home-cooking/src/main/java/com/manning/siia/kitchen/domain/Ingredient.java
+++ b/siia-examples/home-cooking/src/main/java/com/manning/siia/kitchen/domain/Ingredient.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/home-cooking/src/main/java/com/manning/siia/kitchen/domain/Meal.java
+++ b/siia-examples/home-cooking/src/main/java/com/manning/siia/kitchen/domain/Meal.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/home-cooking/src/main/java/com/manning/siia/kitchen/domain/Meat.java
+++ b/siia-examples/home-cooking/src/main/java/com/manning/siia/kitchen/domain/Meat.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/home-cooking/src/main/java/com/manning/siia/kitchen/domain/Product.java
+++ b/siia-examples/home-cooking/src/main/java/com/manning/siia/kitchen/domain/Product.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/home-cooking/src/main/java/com/manning/siia/kitchen/domain/Recipe.java
+++ b/siia-examples/home-cooking/src/main/java/com/manning/siia/kitchen/domain/Recipe.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/home-cooking/src/main/java/com/manning/siia/kitchen/domain/ShoppingList.java
+++ b/siia-examples/home-cooking/src/main/java/com/manning/siia/kitchen/domain/ShoppingList.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/home-cooking/src/main/java/com/manning/siia/kitchen/domain/Vegetable.java
+++ b/siia-examples/home-cooking/src/main/java/com/manning/siia/kitchen/domain/Vegetable.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/home-cooking/src/main/java/com/manning/siia/kitchen/shop/Butcher.java
+++ b/siia-examples/home-cooking/src/main/java/com/manning/siia/kitchen/shop/Butcher.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/home-cooking/src/main/java/com/manning/siia/kitchen/shop/GreenGrocer.java
+++ b/siia-examples/home-cooking/src/main/java/com/manning/siia/kitchen/shop/GreenGrocer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/home-cooking/src/main/java/com/manning/siia/kitchen/shop/Supermarket.java
+++ b/siia-examples/home-cooking/src/main/java/com/manning/siia/kitchen/shop/Supermarket.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/home-cooking/src/main/resources/create-shoppinglists-flow.xml
+++ b/siia-examples/home-cooking/src/main/resources/create-shoppinglists-flow.xml
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/home-cooking/src/main/resources/grocery-unpacker-flow.xml
+++ b/siia-examples/home-cooking/src/main/resources/grocery-unpacker-flow.xml
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/home-cooking/src/main/resources/home-dinner-flow.xml
+++ b/siia-examples/home-cooking/src/main/resources/home-dinner-flow.xml
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/home-cooking/src/main/resources/kitchen.properties
+++ b/siia-examples/home-cooking/src/main/resources/kitchen.properties
@@ -5,7 +5,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/home-cooking/src/main/resources/kitchen.xml
+++ b/siia-examples/home-cooking/src/main/resources/kitchen.xml
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/home-cooking/src/main/resources/recipebook.xml
+++ b/siia-examples/home-cooking/src/main/resources/recipebook.xml
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/home-cooking/src/main/resources/shopping-flow.xml
+++ b/siia-examples/home-cooking/src/main/resources/shopping-flow.xml
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/home-cooking/src/main/resources/split-recipe-flow.xml
+++ b/siia-examples/home-cooking/src/main/resources/split-recipe-flow.xml
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/home-cooking/src/test/java/com/manning/siia/kitchen/CookTest.java
+++ b/siia-examples/home-cooking/src/test/java/com/manning/siia/kitchen/CookTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/home-cooking/src/test/java/com/manning/siia/kitchen/EndToEndIntegrationTest.java
+++ b/siia-examples/home-cooking/src/test/java/com/manning/siia/kitchen/EndToEndIntegrationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/home-cooking/src/test/java/com/manning/siia/kitchen/KitchenTest.java
+++ b/siia-examples/home-cooking/src/test/java/com/manning/siia/kitchen/KitchenTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/home-cooking/src/test/java/com/manning/siia/kitchen/RecipeReadingTest.java
+++ b/siia-examples/home-cooking/src/test/java/com/manning/siia/kitchen/RecipeReadingTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/home-cooking/src/test/java/com/manning/siia/kitchen/RecipeSplitterTest.java
+++ b/siia-examples/home-cooking/src/test/java/com/manning/siia/kitchen/RecipeSplitterTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/home-cooking/src/test/java/com/manning/siia/kitchen/ShoppingTest.java
+++ b/siia-examples/home-cooking/src/test/java/com/manning/siia/kitchen/ShoppingTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/home-cooking/src/test/java/com/manning/siia/kitchen/TimedPollableChannel.java
+++ b/siia-examples/home-cooking/src/test/java/com/manning/siia/kitchen/TimedPollableChannel.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/home-cooking/src/test/java/com/manning/siia/kitchen/domain/DomainTest.java
+++ b/siia-examples/home-cooking/src/test/java/com/manning/siia/kitchen/domain/DomainTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/home-cooking/src/test/java/com/manning/siia/kitchen/domain/MealTest.java
+++ b/siia-examples/home-cooking/src/test/java/com/manning/siia/kitchen/domain/MealTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/home-cooking/src/test/java/com/manning/siia/kitchen/domain/RecipeObjectMother.java
+++ b/siia-examples/home-cooking/src/test/java/com/manning/siia/kitchen/domain/RecipeObjectMother.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/home-cooking/src/test/java/com/manning/siia/kitchen/domain/RecipeTest.java
+++ b/siia-examples/home-cooking/src/test/java/com/manning/siia/kitchen/domain/RecipeTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/home-cooking/src/test/resources/TEST-home-dinner-flow.xml
+++ b/siia-examples/home-cooking/src/test/resources/TEST-home-dinner-flow.xml
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/home-cooking/src/test/resources/TEST-recipe-reader.xml
+++ b/siia-examples/home-cooking/src/test/resources/TEST-recipe-reader.xml
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/home-cooking/src/test/resources/TEST-recipeSplitter.xml
+++ b/siia-examples/home-cooking/src/test/resources/TEST-recipeSplitter.xml
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/home-cooking/src/test/resources/TEST-shopping.xml
+++ b/siia-examples/home-cooking/src/test/resources/TEST-shopping.xml
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/home-cooking/src/test/resources/log4j.properties
+++ b/siia-examples/home-cooking/src/test/resources/log4j.properties
@@ -5,7 +5,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/jms/src/main/java/siia/jms/ChannelAdapterDemo.java
+++ b/siia-examples/jms/src/main/java/siia/jms/ChannelAdapterDemo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/jms/src/main/java/siia/jms/DirectJmsDemo.java
+++ b/siia-examples/jms/src/main/java/siia/jms/DirectJmsDemo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/jms/src/main/java/siia/jms/Exclaimer.java
+++ b/siia-examples/jms/src/main/java/siia/jms/Exclaimer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/jms/src/main/java/siia/jms/GatewayDemo.java
+++ b/siia-examples/jms/src/main/java/siia/jms/GatewayDemo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/jms/src/main/java/siia/jms/Greeter.java
+++ b/siia-examples/jms/src/main/java/siia/jms/Greeter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/jms/src/main/java/siia/jms/JmsTemplateDemo.java
+++ b/siia-examples/jms/src/main/java/siia/jms/JmsTemplateDemo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/jms/src/main/java/siia/jms/MessageDrivenPojoDemo.java
+++ b/siia-examples/jms/src/main/java/siia/jms/MessageDrivenPojoDemo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/jms/src/main/java/siia/jms/MessageListenerContainerDemo.java
+++ b/siia-examples/jms/src/main/java/siia/jms/MessageListenerContainerDemo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/jms/src/main/resources/siia/jms/channel-adapters.xml
+++ b/siia-examples/jms/src/main/resources/siia/jms/channel-adapters.xml
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/jms/src/main/resources/siia/jms/gateways.xml
+++ b/siia-examples/jms/src/main/resources/siia/jms/gateways.xml
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/jms/src/main/resources/siia/jms/message-driven-pojo.xml
+++ b/siia-examples/jms/src/main/resources/siia/jms/message-driven-pojo.xml
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/messages-channels/src/main/java/siia/channels/AuditRecord.java
+++ b/siia-examples/messages-channels/src/main/java/siia/channels/AuditRecord.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/messages-channels/src/main/java/siia/channels/AuditService.java
+++ b/siia-examples/messages-channels/src/main/java/siia/channels/AuditService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/messages-channels/src/main/java/siia/channels/BillForBookingService.java
+++ b/siia-examples/messages-channels/src/main/java/siia/channels/BillForBookingService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/messages-channels/src/main/java/siia/channels/Booking.java
+++ b/siia-examples/messages-channels/src/main/java/siia/channels/Booking.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/messages-channels/src/main/java/siia/channels/ChannelAuditor.java
+++ b/siia-examples/messages-channels/src/main/java/siia/channels/ChannelAuditor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/messages-channels/src/main/java/siia/channels/ChargedBooking.java
+++ b/siia-examples/messages-channels/src/main/java/siia/channels/ChargedBooking.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/messages-channels/src/main/java/siia/channels/CustomerPriorityComparator.java
+++ b/siia-examples/messages-channels/src/main/java/siia/channels/CustomerPriorityComparator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/messages-channels/src/main/java/siia/channels/Email.java
+++ b/siia-examples/messages-channels/src/main/java/siia/channels/Email.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/messages-channels/src/main/java/siia/channels/Seat.java
+++ b/siia-examples/messages-channels/src/main/java/siia/channels/Seat.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/messages-channels/src/main/java/siia/channels/SeatAvailabilityService.java
+++ b/siia-examples/messages-channels/src/main/java/siia/channels/SeatAvailabilityService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/messages-channels/src/main/java/siia/channels/SeatConfirmation.java
+++ b/siia-examples/messages-channels/src/main/java/siia/channels/SeatConfirmation.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/messages-channels/src/main/java/siia/channels/StubEmailConfirmationService.java
+++ b/siia-examples/messages-channels/src/main/java/siia/channels/StubEmailConfirmationService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/messages-channels/src/main/resources/channels-all-direct.xml
+++ b/siia-examples/messages-channels/src/main/resources/channels-all-direct.xml
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/messages-channels/src/main/resources/channels-bridge.xml
+++ b/siia-examples/messages-channels/src/main/resources/channels-bridge.xml
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/messages-channels/src/main/resources/channels-buffered.xml
+++ b/siia-examples/messages-channels/src/main/resources/channels-buffered.xml
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/messages-channels/src/main/resources/channels-interceptor.xml
+++ b/siia-examples/messages-channels/src/main/resources/channels-interceptor.xml
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/messages-channels/src/main/resources/channels-priority.xml
+++ b/siia-examples/messages-channels/src/main/resources/channels-priority.xml
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/messages-channels/src/main/resources/channels-selector.xml
+++ b/siia-examples/messages-channels/src/main/resources/channels-selector.xml
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/messages-channels/src/test/java/siia/channels/AllChannelsDirectTest.java
+++ b/siia-examples/messages-channels/src/test/java/siia/channels/AllChannelsDirectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/messages-channels/src/test/java/siia/channels/ChannelInterceptorTest.java
+++ b/siia-examples/messages-channels/src/test/java/siia/channels/ChannelInterceptorTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/messages-channels/src/test/java/siia/channels/ChannelSelectorTest.java
+++ b/siia-examples/messages-channels/src/test/java/siia/channels/ChannelSelectorTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/messages-channels/src/test/java/siia/channels/ChannelsBridgeTest.java
+++ b/siia-examples/messages-channels/src/test/java/siia/channels/ChannelsBridgeTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/messages-channels/src/test/java/siia/channels/ChannelsBufferedTest.java
+++ b/siia-examples/messages-channels/src/test/java/siia/channels/ChannelsBufferedTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/messages-channels/src/test/java/siia/channels/ChannelsPriorityTest.java
+++ b/siia-examples/messages-channels/src/test/java/siia/channels/ChannelsPriorityTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/monitoring/src/main/java/siia/monitoring/controlbus/ControlBusDemo.java
+++ b/siia-examples/monitoring/src/main/java/siia/monitoring/controlbus/ControlBusDemo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/monitoring/src/main/java/siia/monitoring/controlbus/FilePoller.java
+++ b/siia-examples/monitoring/src/main/java/siia/monitoring/controlbus/FilePoller.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/monitoring/src/main/java/siia/monitoring/controlbus/GroovyControlBusDemo.java
+++ b/siia-examples/monitoring/src/main/java/siia/monitoring/controlbus/GroovyControlBusDemo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/monitoring/src/main/java/siia/monitoring/controlbus/NumberHolder.java
+++ b/siia-examples/monitoring/src/main/java/siia/monitoring/controlbus/NumberHolder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/monitoring/src/main/java/siia/monitoring/history/HistoryDemo1.java
+++ b/siia-examples/monitoring/src/main/java/siia/monitoring/history/HistoryDemo1.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/monitoring/src/main/java/siia/monitoring/history/HistoryDemo2.java
+++ b/siia-examples/monitoring/src/main/java/siia/monitoring/history/HistoryDemo2.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/monitoring/src/main/java/siia/monitoring/jmx/JmxDemo.java
+++ b/siia-examples/monitoring/src/main/java/siia/monitoring/jmx/JmxDemo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/monitoring/src/main/java/siia/monitoring/wiretap/Debit.java
+++ b/siia-examples/monitoring/src/main/java/siia/monitoring/wiretap/Debit.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/monitoring/src/main/java/siia/monitoring/wiretap/DebitService.java
+++ b/siia-examples/monitoring/src/main/java/siia/monitoring/wiretap/DebitService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/monitoring/src/main/java/siia/monitoring/wiretap/WireTapDemo.java
+++ b/siia-examples/monitoring/src/main/java/siia/monitoring/wiretap/WireTapDemo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/monitoring/src/main/resources/siia/monitoring/controlbus/context.xml
+++ b/siia-examples/monitoring/src/main/resources/siia/monitoring/controlbus/context.xml
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/monitoring/src/main/resources/siia/monitoring/controlbus/groovy-context.xml
+++ b/siia-examples/monitoring/src/main/resources/siia/monitoring/controlbus/groovy-context.xml
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/monitoring/src/main/resources/siia/monitoring/history/context1.xml
+++ b/siia-examples/monitoring/src/main/resources/siia/monitoring/history/context1.xml
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/monitoring/src/main/resources/siia/monitoring/history/context2.xml
+++ b/siia-examples/monitoring/src/main/resources/siia/monitoring/history/context2.xml
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/monitoring/src/main/resources/siia/monitoring/jmx/context.xml
+++ b/siia-examples/monitoring/src/main/resources/siia/monitoring/jmx/context.xml
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/monitoring/src/main/resources/siia/monitoring/wiretap/context.xml
+++ b/siia-examples/monitoring/src/main/resources/siia/monitoring/wiretap/context.xml
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/trip-diary/src/main/java/com/manning/siia/trip/diary/ChangeFileNameGenerator.java
+++ b/siia-examples/trip-diary/src/main/java/com/manning/siia/trip/diary/ChangeFileNameGenerator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/trip-diary/src/main/java/com/manning/siia/trip/diary/EditableText.java
+++ b/siia-examples/trip-diary/src/main/java/com/manning/siia/trip/diary/EditableText.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/trip-diary/src/main/java/com/manning/siia/trip/diary/RefuseWrittenByThisProcess.java
+++ b/siia-examples/trip-diary/src/main/java/com/manning/siia/trip/diary/RefuseWrittenByThisProcess.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/trip-diary/src/main/java/com/manning/siia/trip/diary/TextChange.java
+++ b/siia-examples/trip-diary/src/main/java/com/manning/siia/trip/diary/TextChange.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/trip-diary/src/main/java/com/manning/siia/trip/diary/TextChanges.java
+++ b/siia-examples/trip-diary/src/main/java/com/manning/siia/trip/diary/TextChanges.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/trip-diary/src/main/resources/diary-file-exchanger.xml
+++ b/siia-examples/trip-diary/src/main/resources/diary-file-exchanger.xml
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/trip-diary/src/test/java/com/manning/siia/trip/diary/ChangeFileNameGeneratorTest.java
+++ b/siia-examples/trip-diary/src/test/java/com/manning/siia/trip/diary/ChangeFileNameGeneratorTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/trip-diary/src/test/java/com/manning/siia/trip/diary/EditableTextTest.java
+++ b/siia-examples/trip-diary/src/test/java/com/manning/siia/trip/diary/EditableTextTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/trip-diary/src/test/java/com/manning/siia/trip/diary/ExchangerIntegrationTest.java
+++ b/siia-examples/trip-diary/src/test/java/com/manning/siia/trip/diary/ExchangerIntegrationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/trip-diary/src/test/resources/com/manning/siia/trip/diary/ExchangerIntegrationTest-context.xml
+++ b/siia-examples/trip-diary/src/test/resources/com/manning/siia/trip/diary/ExchangerIntegrationTest-context.xml
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/trip-diary/src/test/resources/diary.properties
+++ b/siia-examples/trip-diary/src/test/resources/diary.properties
@@ -5,7 +5,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/trip-diary/src/test/resources/log4j.properties
+++ b/siia-examples/trip-diary/src/test/resources/log4j.properties
@@ -5,7 +5,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/twitter/src/main/java/siia/twitter/SearchAnalysis.java
+++ b/siia-examples/twitter/src/main/java/siia/twitter/SearchAnalysis.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/twitter/src/main/java/siia/twitter/SearchResultAnalzyer.java
+++ b/siia-examples/twitter/src/main/java/siia/twitter/SearchResultAnalzyer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/twitter/src/main/java/siia/twitter/SearchToLog.java
+++ b/siia-examples/twitter/src/main/java/siia/twitter/SearchToLog.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/twitter/src/main/java/siia/twitter/TimelineToLog.java
+++ b/siia-examples/twitter/src/main/java/siia/twitter/TimelineToLog.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/twitter/src/main/resources/siia/twitter/oauth.properties
+++ b/siia-examples/twitter/src/main/resources/siia/twitter/oauth.properties
@@ -5,7 +5,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/twitter/src/main/resources/siia/twitter/search-analysis.xml
+++ b/siia-examples/twitter/src/main/resources/siia/twitter/search-analysis.xml
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/twitter/src/main/resources/siia/twitter/search-to-log.xml
+++ b/siia-examples/twitter/src/main/resources/siia/twitter/search-to-log.xml
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/twitter/src/main/resources/siia/twitter/timeline-to-log.xml
+++ b/siia-examples/twitter/src/main/resources/siia/twitter/timeline-to-log.xml
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/webapp/src/main/java/com/manning/siia/OkResponse.java
+++ b/siia-examples/webapp/src/main/java/com/manning/siia/OkResponse.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/webapp/src/main/java/com/manning/siia/TripQuoteRequestProcessor.java
+++ b/siia-examples/webapp/src/main/java/com/manning/siia/TripQuoteRequestProcessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/webapp/src/main/resources/trips-applicationContext.xml
+++ b/siia-examples/webapp/src/main/resources/trips-applicationContext.xml
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/webapp/src/main/webapp/WEB-INF/applicationContext.xml
+++ b/siia-examples/webapp/src/main/webapp/WEB-INF/applicationContext.xml
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/webapp/src/main/webapp/WEB-INF/http-ws-servlet.xml
+++ b/siia-examples/webapp/src/main/webapp/WEB-INF/http-ws-servlet.xml
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/webapp/src/main/webapp/WEB-INF/log4j.properties
+++ b/siia-examples/webapp/src/main/webapp/WEB-INF/log4j.properties
@@ -5,7 +5,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/webapp/src/main/webapp/WEB-INF/soap-ws-servlet.xml
+++ b/siia-examples/webapp/src/main/webapp/WEB-INF/soap-ws-servlet.xml
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/webapp/src/main/webapp/WEB-INF/web.xml
+++ b/siia-examples/webapp/src/main/webapp/WEB-INF/web.xml
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/webapp/src/test/java/com/manning/siia/soap/SoapTripTestClient.java
+++ b/siia-examples/webapp/src/test/java/com/manning/siia/soap/SoapTripTestClient.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/siia-examples/webapp/src/test/resources/com/manning/siia/soap/soap-client-applicationContext.xml
+++ b/siia-examples/webapp/src/test/resources/com/manning/siia/soap/soap-client-applicationContext.xml
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/ with 1 occurrences migrated to:  
  https://www.apache.org/licenses/ ([https](https://www.apache.org/licenses/) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 295 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).